### PR TITLE
add Podman compatible containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,6 @@
+# Start from the official Go alpine image
+FROM docker.io/library/golang:alpine
+# Set WD in container
+WORKDIR /app
+# Install latest SSHamble from github
+RUN go install github.com/runZeroInc/sshamble@latest


### PR DESCRIPTION
Adding a few simple lines for those of us that prefer to keep our tools containerized.


this allows us to run a podman build and have a local container image of the tool