### PR TITLE
output to file: Truncate output file on open

### DIFF
--- a/cmd/cmd_scan.go
+++ b/cmd/cmd_scan.go
@@ -177,7 +177,7 @@ func runScan(cmd *cobra.Command, args []string) {
 		case "stderr":
 			outputWriter = os.Stderr
 		default:
-			outputWriter, err = os.OpenFile(gOutput, os.O_WRONLY|os.O_CREATE, 0o600)
+			outputWriter, err = os.OpenFile(gOutput, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 			if err != nil {
 				conf.Logger.Fatalf("failed to create output file %s: %v", gOutput, err)
 			}


### PR DESCRIPTION
With the current flags on the OpenFile() call, the output file will not be truncated, which means that previous scans with longer outputs will result in trailing garbage (typically leading to invalid JSON).

This change adds os.O_TRUNC to truncate the file on open.

Steps to reproduce the problem/verify the solution:

```
$ dd if=/dev/zero of=scan.json count=100
10000+0 records in
10000+0 records out
5120000 bytes (5.1 MB, 4.9 MiB) copied, 0.279659 s, 18.3 MB/s
$ sshamble scan localhost -o scan.json
time="2024-08-12 10:06:27" level=info msg="localhost:22 pubkey-bulkhalf completed on iteration 5 with result auth-failed (ssh: disconnect, reason 2: Too many authentication failures)"
$ xxd < scan.json |head -n 130|tail -n 5
000007d0: 3037 2c22 7075 624b 6579 4861 6c66 4175  07,"pubKeyHalfAu
000007e0: 7468 4c69 6d69 7422 3a35 7d0a 0000 0000  thLimit":5}.....
000007f0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000800: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000810: 0000 0000 0000 0000 0000 0000 0000 0000  ................
```